### PR TITLE
Add MacOS build instructions for cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Open the Terminal app to run the following commands. If you are unfamiliar with 
 brew install cmake
 ```
 
-*Create a build folder:*
+*Create a build folder in the project root directory:*
 
 ```bash
+cd jsxbin_decompiler
 mkdir build
 cd build
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,30 @@ A faster decompiler for Adobe's ExtendScript (Legacy) binary format (*.jsxbin).
 ## What is ExtendScript?
 ExtendScript is a scripting language and an associated toolkit developed by Adobe Systems, intended for use with Creative Suite and Technical Communication Suite products. It is a dialect of the ECMAScript 3 standard and therefore similar to JavaScript and ActionScript. The toolkit comes bundled with Creative Suite and Technical Communication Suite editions and can access tools within applications like Photoshop, FrameMaker, InDesign or After Effects for batch-processing projects.
 
+## Build (MacOS)
+
+Open the Terminal app to run the following commands. If you are unfamiliar with Terminal, you can find it in /Applications/Utilities/Terminal.app.
+
+*Install CMake:*
+
+```bash
+brew install cmake
+```
+
+*Create a build folder:*
+
+```bash
+mkdir build
+cd build
+```
+
+*Configure and build the project:*
+
+```bash
+cmake ..
+cmake --build . --config release 
+```
+
 ## Credits
   - Thanks to `@autoboosh` for his project [jsxbin-to-jsx-converter](https://github.com/autoboosh/jsxbin-to-jsx-converter).
   - Thanks to `@codecopy` for keeping a [fork](https://github.com/codecopy/jsxbin-to-jsx-converter) of `@autoboosh`'s project, where `@autoboosh` vanished from GitHub.


### PR DESCRIPTION
I don't have access to test building on other platforms so I focused solely on building for Mac OS Intel computers.