### PR TITLE
Add usage info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ cmake .
 cmake --build . --config release 
 ```
 
+*After a successful build, navigate to the folder with the executable:*
+```bash
+cd ./bin/release/
+```
+
+## Usage
+
+> **Note**
+> Make sure that the input file only contains the JSXBIN literal itself.<sup><a href="https://youtu.be/939Bo5iTxo0?lc=UgyPDxgsuRmbfd8MI-F4AaABAg.9gIEl4rxFVa9gIFW1EPzqO">\[1\]</a></sup>&ensp;(Usually starting with `@JSXBIN@`)
+
+```bash
+jsxer <jsxbin path> <output path> [--jsxblind]
+```
+
+The `--jsxblind` flag enables the experimental deobfuscation.
+
 ## Credits
   - Thanks to Andrin Meier ([@andrinmeier](https://github.com/andrinmeier), formerly `@autoboosh`) for his research on the format, and his project [jsxbin-to-jsx-converter](https://github.com/autoboosh/jsxbin-to-jsx-converter).
   - Thanks to [@codecopy](https://github.com/codecopy) for keeping a [fork](https://github.com/codecopy/jsxbin-to-jsx-converter) of `@autoboosh`'s project, where the original vanished as a consequence of a DMCA takedown from Adobe.


### PR DESCRIPTION
I was stuck on this for a really long time, as I kept getting the `JSXBIN signature verification failed!` parse error, and my input JSXINC file looked roughly like this:

```js
/* Some comments with info */
eval("@JSXBIN@ES@1.0@ … ");
```

Luckily thanks to a YouTube comment by @AngeloD2022 [(link)](https://www.youtube.com/watch?v=939Bo5iTxo0&lc=UgyPDxgsuRmbfd8MI-F4AaABAg.9gIEl4rxFVa9gIFW1EPzqO#linked-comment-badge), I stripped the file to just the JSXBIN literal like so:

```java
@JSXBIN@ES@1.0@ …
```

and it all worked perfectly afterwards. I'd just like to include this in the README!